### PR TITLE
Corrected casing on ConnectionRoutes require

### DIFF
--- a/server/config/middleware.js
+++ b/server/config/middleware.js
@@ -2,7 +2,7 @@ var morgan      = require('morgan'), // used for logging incoming request
     bodyParser  = require('body-parser');
 
 module.exports = function (app, express, Users, Connections) {
-  // var connectionRouter = express.Router();
+  var connectionRouter = express.Router();
   var userRouter = express.Router();
 
   app.set('view engine', 'html');
@@ -11,11 +11,11 @@ module.exports = function (app, express, Users, Connections) {
   app.use(bodyParser.json());
   app.use(express.static('public'));
 
-  // app.use('/connection', connectionRouter); // user connection router for connection updates
+  app.use('/connection', connectionRouter); // user connection router for connection updates
   app.use('/user', userRouter); // use user router for all user request
 
 
   // // inject our routers into their respective route files
-  // require('../connections/connectionRoutes.js')(connectionRouter, Connections);
+  require('../connections/ConnectionRoutes.js')(connectionRouter, Connections);
   require('../users/UserRoutes.js')(userRouter, Users);
 };


### PR DESCRIPTION
Found that the mismatched casing for the route requires was causing an application error.
